### PR TITLE
fix: generateKeyPair for non node environments

### DIFF
--- a/src/curve.js
+++ b/src/curve.js
@@ -63,7 +63,7 @@ exports.generateKeyPair = function() {
         const keyPair = curveJs.generateKeyPair(nodeCrypto.randomBytes(32));
         return {
             privKey: Buffer.from(keyPair.private),
-            pubKey: Buffer.from(keyPair.public),
+            pubKey: Buffer.concat([Buffer.from([5]), Buffer.from(keyPair.public)]),
         };
     }
 };


### PR DESCRIPTION
Node's generateKeyPairSync function generates a public key of length 44, which then gets sliced down to 33 bytes with the first byte of the sliced down key being the number `5`.
However the CurveJs generateKeyPair function generates a public key of length 32.
I added the number 5 as a prefix to the CurveJs public key to be consistent with the node function. 